### PR TITLE
Include configuration for vagrant-hostmanager plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ We can now spin up the VM and test the instance in there.
 
     vagrant up
 
-TODO: figure out a good way to find the VM's IP and point some hostname to this
-IP.
+### Using vagrant-hostmanager
 
+[vagrant-hostmanager][1] is a vagrant plugin which will update active guest and,
+optionally, the host's /etc/hosts file. If it's installed, host entries should
+the default hostname of the guest, alternc.local, and test.alternc.local will be
+configured automatically and removed when the the guest is destroyed. Wildcards
+are not allowed in host files, so if further names are required they must be
+added in the Vagrantfile.
+
+Note: You will be prompted for sudo access when starting to destroying unless
+the sudoers configuration listed in the vagrant-hostmanager readme is done.
+
+[1]: https://github.com/devopsgroup-io/vagrant-hostmanager/releases

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@
 # backwards compatibility). Please don't change it unless you know what
 # you're doing.
 Vagrant.configure(2) do |config|
-  config.vm.box = "debian-9-amd64"
+  config.vm.box = "koumbit/stretch64"
 
   config.ssh.insert_key = false
 
@@ -37,5 +37,14 @@ Vagrant.configure(2) do |config|
       # by using NFSv4 everywhere. Please note that the tcp option is not the default.
       mount_options: ['rw', 'vers=3', 'tcp', 'nolock']
     }
+  end
+
+  if Vagrant.has_plugin?("vagrant-hostmanager")
+    config.hostmanager.enabled = true
+    config.hostmanager.manage_host = true
+    config.hostmanager.manage_guest = true
+    config.hostmanager.ignore_private_ip = false
+    config.hostmanager.include_offline = true
+    config.hostmanager.aliases = %w(alternc.local test.alternc.local)
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@
 # backwards compatibility). Please don't change it unless you know what
 # you're doing.
 Vagrant.configure(2) do |config|
-  config.vm.box = "koumbit/stretch64"
+  config.vm.box = "debian-9-amd64"
 
   config.ssh.insert_key = false
 


### PR DESCRIPTION
The vagrant-hostmanager plugin can be used to manage entries in the hosts files.

Normally I would include the vagrant plugin installation instructions:

    vagrant plugin install vagrant-hostmanager

but there's dependency conflicts (at least for me) with ruby-openssl in debian. I filed an ITP and started working on packaging: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=898996. 